### PR TITLE
Fix hanging progress indicator

### DIFF
--- a/src/android/ActivityIndicator.java
+++ b/src/android/ActivityIndicator.java
@@ -3,7 +3,7 @@ package org.apache.cordova.plugin;
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
 import org.json.JSONArray;
-import org.json.JSONException; 
+import org.json.JSONException;
 import org.apache.cordova.plugin.AndroidProgressHUD;
 
 public class ActivityIndicator extends CordovaPlugin {
@@ -36,6 +36,10 @@ public class ActivityIndicator extends CordovaPlugin {
 
 		cordova.getActivity().runOnUiThread(new Runnable() {
 			public void run() {
+				if (activityIndicator != null) {
+					activityIndicator.dismiss();
+					activityIndicator = null;
+				}
 				activityIndicator = AndroidProgressHUD.show(ActivityIndicator.this.cordova.getActivity(), ActivityIndicator.this.text, true,true,null);
 			}
 		});

--- a/src/ios/ActivityIndicator.m
+++ b/src/ios/ActivityIndicator.m
@@ -11,6 +11,9 @@
 - (void)show:(CDVInvokedUrlCommand*)command
 {
 	NSString* text = [command.arguments objectAtIndex:0];
+	if (self.activityIndicator) {
+		[self.activityIndicator hide:YES];
+	}
 	self.activityIndicator = nil;
 	self.activityIndicator = [MBProgressHUD showHUDAddedTo:self.webView.superview animated:YES];
 	self.activityIndicator.mode = MBProgressHUDModeIndeterminate;


### PR DESCRIPTION
It happens more often than not than when two consecutive show() are called the progress indicator hangs as it holds only a reference to the last activity indicator.
This PR makes sure when show() is called to hide the progress indicator if it exists.