### PR TITLE
Run hide in the UI thread

### DIFF
--- a/src/android/ActivityIndicator.java
+++ b/src/android/ActivityIndicator.java
@@ -3,13 +3,12 @@ package org.apache.cordova.plugin;
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
 import org.json.JSONArray;
-import org.json.JSONException; 
+import org.json.JSONException;
 import org.apache.cordova.plugin.AndroidProgressHUD;
 
 public class ActivityIndicator extends CordovaPlugin {
 
 	private AndroidProgressHUD activityIndicator = null;
-	private String text = null;
 
 	@Override
 	public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
@@ -31,12 +30,10 @@ public class ActivityIndicator extends CordovaPlugin {
 	 * This show the ProgressDialog
 	 * @param text - Message to display in the Progress Dialog
 	 */
-	public void show(String text) {
-		this.text = text;
-
+	public void show(final String text) {
 		cordova.getActivity().runOnUiThread(new Runnable() {
 			public void run() {
-				activityIndicator = AndroidProgressHUD.show(ActivityIndicator.this.cordova.getActivity(), ActivityIndicator.this.text, true,true,null);
+				activityIndicator = AndroidProgressHUD.show(ActivityIndicator.this.cordova.getActivity(), text, true,true,null);
 			}
 		});
 	}
@@ -45,9 +42,13 @@ public class ActivityIndicator extends CordovaPlugin {
 	 * This hide the ProgressDialog
 	 */
 	public void hide() {
-		if (activityIndicator != null) {
-			activityIndicator.dismiss();
-			activityIndicator = null;
-		}
+		cordova.getActivity().runOnUiThread(new Runnable() {
+			public void run() {
+				if (activityIndicator != null) {
+					activityIndicator.dismiss();
+					activityIndicator = null;
+				}
+			}
+		});
 	}
 }


### PR DESCRIPTION
After noticing that sometimes a call to hide fails to hide a previously shown dialog
I realized that not run hide in the same thread as show is the reason why.
The problematic situation is the following:
call show(text) and immediately call hide()
The dialog will be initialized as soon as the UI thread decides to execute the Runnable added in show
if the Runnable has not been executed when calling he hide method then one ends up in a situation where hide has been called but the dialog is hidden as expected.
By running the hide code in the UI thread queues the call to dismiss the dialog after the call to show it thus solving the issue.
I also took the liberty to remove the static text variable since there is no need for having it if text is declared final in the definition of the show method.  